### PR TITLE
added sorting algorithm

### DIFF
--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1925,12 +1925,13 @@ end subroutine convective_adjustment
 
 !------------------------------------------------------------------------------
 !> Return the index of a sorted array of scalar values
-subroutine sort_scalar_k(G, GV, h, tv, ksort)
+subroutine sort_scalar_k(G, GV, h, phi, ksort)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
   real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(inout) :: h    !< Layer thicknesses [H ~> m or kg m-2]
-  type(thermo_var_ptrs),   intent(inout) :: tv   !< A structure pointing to various thermodynamic variables
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV), &
+                           intent(in)    :: phi  !< Array of scalar quantity to be sorted
   integer, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: ksort !< An array of indicies for a 
                                                   !! monotonically increasing scalar
@@ -1942,7 +1943,7 @@ subroutine sort_scalar_k(G, GV, h, tv, ksort)
 
   ! Local variables
   integer   :: i, j, k
-  real      :: T0, T1       ! temperatures
+  real      :: P0, P1       ! temperatures
   logical   :: monotonic
 
   ! Loop on columns
@@ -1953,10 +1954,10 @@ subroutine sort_scalar_k(G, GV, h, tv, ksort)
       monotonic = .true.
       do k = 1,GV%ke-1
         ! Gather information of scalar value in current and next cells
-        T0 = tv%T(i,j,k)  ; T1 = tv%T(i,j,k+1)
+        P0 = phi(i,j,k)  ; P1 = phi(i,j,k+1)
         ! If the scalar value of the current cell is larger than the scalar
         ! below it, we swap the cell indices
-        if ( T0 > T1 ) then
+        if ( P0 > P1 ) then
           ksort(i,j,k) = k+1 ; ksort(i,j,k+1) = k
           monotonic = .false.
         endif

--- a/src/ALE/MOM_regridding.F90
+++ b/src/ALE/MOM_regridding.F90
@@ -1928,7 +1928,7 @@ end subroutine convective_adjustment
 subroutine sort_scalar_k_1d(G, GV, phi, ksort)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZK_(GV), &
+  real, dimension(SZK_(GV)), &
                            intent(in)    :: phi  !< Array of scalar quantity to be sorted
   integer, dimension(SZK_(GV)), &
                            intent(out) :: ksort !< An array of indicies for a 
@@ -1968,7 +1968,7 @@ end subroutine sort_scalar_k_1d
 subroutine sort_scalar_k(G, GV, phi, ksort)
   type(ocean_grid_type),   intent(in)    :: G    !< The ocean's grid structure
   type(verticalGrid_type), intent(in)    :: GV   !< The ocean's vertical grid structure
-  real, dimension(SZI_(G),SZJ_(G),SZK_(GV), &
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(in)    :: phi  !< Array of scalar quantity to be sorted
   integer, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
                            intent(out) :: ksort !< An array of indicies for a 


### PR DESCRIPTION
Just pushing this initial commit to test workflow.

I have written a subroutine called `sort_scalar_k`, which is just a copy of the `convective_adjustment` bubble sorting algorithm, but designed to search through *temperature* and return only the sorted index `ksort`, nothing is done to the temperature field itself.

The code has not been tested, but it does compile.

Some outstanding questions:
1. How to do generalize this for an arbitrary tracer in the ocean?
2. The algorithm builds a 3d array, ksort. Would it perhaps be better if the subroutine operated on a single column, which could be called at some point in the grid building step (avoiding allocation of a full 3d array)?
3. At present it follows convective adjustment by sorting everything to be monotonically increasing from surface to depth. This will mean inverting the whole water column in some places for temperature, which is likely to be inefficient. Perhaps functionality to choose it to be increasing or decreasing with depth would be valuable.